### PR TITLE
docs: manual installation

### DIFF
--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -142,35 +142,39 @@ Prerequisites:
 - JoinMarket
 - [docker](#with-docker) or [node & npm](#without-docker)
 
-If you have [successfully installed JoinMarket][jm-install-docs], start
-`jmwalletd` and `ob-watcher`. It is recommended to install them as system
-services, e.g. via `systemd`. Also, see your `joinmarket.cfg` config file
-and adapt the values to your needs. It is generally advised to leave
-all settings at their default values. The following examples all
-use the standard values (e.g. for ports).
-
-[jm-install-docs]: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/INSTALL.md
-
-
-!!! info
-    Never expose your JoinMarket services publicly to your local network,
-    i.e. always bind to `127.0.0.1` instead of `0.0.0.0`.
-
-To start the services manually, navigate to JoinMarket's root directory and
-execute:
+If you have [successfully installed JoinMarket][jm-install-docs], navigate to JoinMarket's root directory and start
+`jmwalletd` and `ob-watcher`:
 
 ```sh
 . jmvenv/bin/activate
 python3 scripts/jmwalletd.py
 ```
-and
+
 ```sh
 . jmvenv/bin/activate
 python3 scripts/obwatch/ob-watcher.py --host=127.0.0.1
 ```
 
-#### With docker
-```
+It is recommended to install both services as system services, e.g. via
+`systemd`. Also, see your `joinmarket.cfg` config file and adapt the values to
+your needs. It is generally advised to leave all settings at their default
+values. The above commands all use the standard values (e.g. for ports).
+
+[jm-install-docs]: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/INSTALL.md
+
+
+!!! info
+    Bind both services to `127.0.0.1` instead of `0.0.0.0` to not expose them to
+    your local network.
+
+Once `jmwalletd` and `ob-watcher` are running, the last thing to do is to launch
+Jam. You can either run the docker image, or download the source code and run it
+via npm. If you run Jam via the `docker` image, you will have to make sure that
+the "internal" host is used:
+
+```sh
+# Option 1: run Jam via docker
+
 docker run --rm  -it \
         --add-host=host.docker.internal:host-gateway \
         --env JMWEBUI_JMWALLETD_HOST="host.docker.internal" \
@@ -180,18 +184,21 @@ docker run --rm  -it \
         ghcr.io/joinmarket-webui/joinmarket-webui-ui-only:v0.0.10-clientserver-v0.9.6
 ```
 
-#### Without docker
-
-Download, [verify][verification] and run Jam.
-
 ```sh
+# Option 2: run Jam via npm
+
 git clone https://github.com/joinmarket-webui/jam.git --branch v0.0.10 --depth=1
 cd jam/
 npm install
 npm start
 ```
 
-A browser should automatically be opened on `http://localhost:3000`.
+!!! success
+    Always make sure to [verify the code][verification] that you run.
+
+When successful, a browser pointing to `http://localhost:3000` should
+automatically be opened.
+
 
 ### ...connecting to a remote JoinMarket instance
 

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -203,7 +203,7 @@ automatically be opened.
 ### ...connecting to a remote JoinMarket instance
 
 Do all the same steps as in [Connecting to a local JoinMarket instance](#connecting-to-a-local-joinmarket-instance)
-but before starting Jam (either directory or with docker), create a ssh tunnel
+but before starting Jam (either directly or with docker), create a ssh tunnel
 to the remote host.
 
 ```sh

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -65,10 +65,11 @@ v1.8.0](https://github.com/rootzoll/raspiblitz/issues/2891).
 
 ## Manual Installation
 
-There are multiple ways to run Jam.
-- Using the official standalone docker image (easiest)
-- Running Jam connecting to a local JoinMarket instance
-- Running Jam connecting to a remote JoinMarket instance
+There are three ways to set up Jam manually:
+
+1. Official standalone docker image (easiest)
+2. Connect Jam to a local JoinMarket instance
+3. Connect Jam to a remote JoinMarket instance
 
 All these methods have benefits and drawbacks. One method is easy, but you
 have less control. Others give you more flexibility, but require several
@@ -76,7 +77,7 @@ manual steps. Choose the method that works best for you.
 The rule of thumb is: Always prefer to build and verify the applications
 locally yourself if you have the necessary technical skills to do so.
 
-### Using docker
+### ...with docker image
 
 Using docker is the easiest way to run JoinMarket with Jam.
 However, a disadvantage is that you have to trust the developers and it is
@@ -125,7 +126,7 @@ docker run --rm  -it \
         ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.10-clientserver-v0.9.6
 ```
 
-### Connecting to a local JoinMarket instance
+### ...running a local JoinMarket instance
 
 Prerequisites:
 - Bitcoin Core
@@ -134,7 +135,7 @@ Prerequisites:
 - [docker](#with-docker) or [node & npm](#without-docker)
 
 If you have [successfully installed JoinMarket][jm-install-docs], start
-`jmwalletd` and `ob-watcher`. It is recommended to install them as system 
+`jmwalletd` and `ob-watcher`. It is recommended to install them as system
 services, e.g. via `systemd`. Also, see your `joinmarket.cfg` config file
 and adapt the values to your needs. It is generally advised to leave
 all settings at their default values. The following examples all
@@ -144,7 +145,7 @@ use the standard values (e.g. for ports).
 
 
 !!! info
-    Never expose your JoinMarket services publicly to your local network, 
+    Never expose your JoinMarket services publicly to your local network,
     i.e. always bind to `127.0.0.1` instead of `0.0.0.0`.
 
 To start the services manually, navigate to JoinMarket's root directory and
@@ -182,9 +183,9 @@ npm install
 npm start
 ```
 
-A browser should automatically be opened on `http://localhost:3000`. 
+A browser should automatically be opened on `http://localhost:3000`.
 
-### Connecting to a remote JoinMarket instance
+### ...running a remote JoinMarket instance
 
 Do all the same steps as in [Connecting to a local JoinMarket instance](#connecting-to-a-local-JoinMarket-instance)
 but before starting Jam (either directory or with docker), create a ssh tunnel

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -108,8 +108,8 @@ docker run --rm  -it \
 ```
 
 If you are connecting to a local Bitcoin Core node, use the above command but
-add param `--add-host=host.docker.internal:host-gateway` and set env variable
-`JM_RPC_HOST` to `host.docker.internal`.
+add param `--add-host=host.docker.internal:host-gateway` and set the environment
+variable `JM_RPC_HOST` to `host.docker.internal`.
 
 After starting the container, Jam can be accessed by visiting
 `http://localhost:8080` in your browser.

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -67,9 +67,9 @@ v1.8.0](https://github.com/rootzoll/raspiblitz/issues/2891).
 
 There are three ways to set up Jam manually:
 
-1. Official standalone docker image (easiest)
-2. Connect Jam to a local JoinMarket instance
-3. Connect Jam to a remote JoinMarket instance
+1. [Run the standalone docker image](#with-docker-image) (easiest)
+2. [Connect Jam to a local JoinMarket instance](#connecting-to-a-local-joinmarket-instance)
+3. [Connect Jam to a remote JoinMarket instance](#connecting-to-a-remote-joinmarket-instance)
 
 All these methods have benefits and drawbacks. One method is easy, but you
 have less control. Others give you more flexibility, but require several
@@ -126,7 +126,7 @@ docker run --rm  -it \
         ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.10-clientserver-v0.9.6
 ```
 
-### ...running a local JoinMarket instance
+### ...connecting to a local JoinMarket instance
 
 Prerequisites:
 - Bitcoin Core
@@ -185,7 +185,7 @@ npm start
 
 A browser should automatically be opened on `http://localhost:3000`.
 
-### ...running a remote JoinMarket instance
+### ...connecting to a remote JoinMarket instance
 
 Do all the same steps as in [Connecting to a local JoinMarket instance](#connecting-to-a-local-JoinMarket-instance)
 but before starting Jam (either directory or with docker), create a ssh tunnel

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -135,7 +135,7 @@ services, e.g. via `systemd`.
 
 [jm-install-docs]: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/INSTALL.md
 
-To start the services manually, nagivate to JoinMarket's `scripts`
+To start the services manually, navigate to JoinMarket's `scripts`
 directory and execute:
 
 ```sh

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -65,7 +65,111 @@ v1.8.0](https://github.com/rootzoll/raspiblitz/issues/2891).
 
 ## Manual Installation
 
+There are multiple ways to run Jam.
+- Using the official standalone docker image (easiest)
+- Running Jam connecting to a local JoinMarket instance
+- Running Jam connecting to a remote JoinMarket instance
+
+All these methods have benefits and drawbacks. One method is easy, but you
+have less control. Others give you more flexibility, but require several
+manual steps. Choose the method that works best for you.
+
+### Using docker
+
+Using docker is the easiest way to run Jam and JoinMarket.
+
+Prerequisites:
+- Bitcoin Core
+- docker
+
+The official [Jam standalone docker image][jam-docker-standalone]
+is already bundled with JoinMarket and Tor. It takes care of starting all
+subservices (API, Orderbook, etc.) and everything works out-of-the-box.
+
+[jam-docker-standalone]: https://github.com/joinmarket-webui/jam-docker/pkgs/container/joinmarket-webui-standalone
+
+If you are connecting to a remote Bitcoin Core node, run:
+```sh
+docker run --rm  -it \
+        --env JM_RPC_HOST="IP_OF_HOST_RUNNING_BITCOIN_CORE" \
+        --env JM_RPC_PORT="8332" \
+        --env JM_RPC_USER="MY_BTC_RPC_USER" \
+        --env JM_RPC_PASSWORD="****************" \
+        --env APP_USER="MY_JAM_USER" \
+        --env APP_PASSWORD="****************" \
+        --publish "8080:8080" \
+        ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.10-clientserver-v0.9.6
+```
+
+If you are connecting to a local Bitcoin Core node, use the above command but
+add param `--add-host=host.docker.internal:host-gateway` and set env variable
+`JM_RPC_HOST` to `host.docker.internal`.
+
+After starting the container, Jam can be accessed by visiting
+`http://localhost:8080` in your browser.
+
+Replace the variables in the commands above to your needs, e.g.:
+```sh
+docker run --rm  -it \
+        --env JM_RPC_HOST="192.168.1.1" \
+        --env JM_RPC_PORT="8332" \
+        --env JM_RPC_USER="bitcoin" \
+        --env JM_RPC_PASSWORD="LXDDdLDf3aOmJ12Dd228i0BQTy5v3LH4" \
+        --env APP_USER="jam" \
+        --env APP_PASSWORD="v2tjeUwZFtUza1w6Ag0CzPJHgoNHUuxl" \
+        --publish "8080:8080" \
+        ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.10-clientserver-v0.9.6
+```
+
+### Connecting to a local JoinMarket instance
+
+Prerequisites:
+- Bitcoin Core
+- Tor
+- JoinMarket
+- [docker](#with-docker) or [node & npm](#without-docker)
+
+If you have [successfully installed JoinMarket][jm-install-docs], start
+`jmwalletd` and `ob-watcher`. It is recommended to install them as system 
+services, e.g. via `systemd`.
+
+[jm-install-docs]: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/INSTALL.md
+
+To start the services manually, nagivate to JoinMarket's `scripts`
+directory and execute:
+
+```sh
+python3 jmwalletd.py
+```
+and
+```sh
+python3 obwatch/ob-watcher.py --host=127.0.0.1
+```
+
+#### With docker
 TODO
+
+#### Without docker
+
+Download, [verify][verification] and run Jam.
+
+```sh
+git clone https://github.com/joinmarket-webui/jam.git --branch v0.0.10 --depth=1
+cd jam/
+npm install
+npm start
+```
+
+A browser should automatically be opened on `http://localhost:3000`. 
+
+### Connecting to a remote JoinMarket instance
+
+Do all the same steps as in [Connecting to a local JoinMarket instance](#connecting-to-a-local-JoinMarket-instance)
+but before starting Jam, create a ssh tunnel to the remote host.
+
+```sh
+ssh yourhost.local -v -o GatewayPorts=true -N -L 28183:0.0.0.0:28183 -L 28283:0.0.0.0:28283 -L 62601:0.0.0.0:62601
+```
 
 ---
 

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -189,7 +189,7 @@ A browser should automatically be opened on `http://localhost:3000`.
 
 ### ...connecting to a remote JoinMarket instance
 
-Do all the same steps as in [Connecting to a local JoinMarket instance](#connecting-to-a-local-JoinMarket-instance)
+Do all the same steps as in [Connecting to a local JoinMarket instance](#connecting-to-a-local-joinmarket-instance)
 but before starting Jam (either directory or with docker), create a ssh tunnel
 to the remote host.
 

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -84,6 +84,7 @@ However, a disadvantage is that you have to trust the developers and it is
 rather difficult to verify the authenticity.
 
 Prerequisites:
+
 - Bitcoin Core
 - docker
 
@@ -129,6 +130,7 @@ docker run --rm  -it \
 ### ...connecting to a local JoinMarket instance
 
 Prerequisites:
+
 - Bitcoin Core
 - Tor
 - JoinMarket

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -114,18 +114,24 @@ variable `JM_RPC_HOST` to `host.docker.internal`.
 After starting the container, Jam can be accessed by visiting
 `http://localhost:8080` in your browser.
 
-Replace the variables in the commands above to your needs, e.g.:
+Make sure to replace the above dummy values for IP, port, RPC username, and RPC
+password with values appropriate to your setup. For example:
+
 ```sh
 docker run --rm  -it \
         --env JM_RPC_HOST="192.168.1.1" \
         --env JM_RPC_PORT="8332" \
         --env JM_RPC_USER="bitcoin" \
-        --env JM_RPC_PASSWORD="LXDDdLDf3aOmJ12Dd228i0BQTy5v3LH4" \
+        --env JM_RPC_PASSWORD="n5a___YOUR_RPC_PASSWORD___yNA" \
         --env APP_USER="jam" \
-        --env APP_PASSWORD="v2tjeUwZFtUza1w6Ag0CzPJHgoNHUuxl" \
+        --env APP_PASSWORD="AvQ___YOUR_APP_PASSWORD___iCw" \
         --publish "8080:80" \
         ghcr.io/joinmarket-webui/joinmarket-webui-standalone:v0.0.10-clientserver-v0.9.6
 ```
+
+Please use your password manager or something like `openssl rand -base64 32` to
+generate strong passwords.
+
 
 ### ...connecting to a local JoinMarket instance
 


### PR DESCRIPTION
First version of section "manual installation".

This still uses the currently valid but soon outdated image name prefix (`joinmarket-webui-`) and env variables.
These need to be adapted after the next release.

I am not to happy with some phrasing. Most important thing is, that the commands are valid.
Any inputs or suggestions are highly appreciated :pray: 