### PR TITLE
docs(install): info about self-signed ssl certificate

### DIFF
--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -146,8 +146,19 @@ Prerequisites:
 - JoinMarket
 - [docker](#with-docker) or [node & npm](#without-docker)
 
-If you have [successfully installed JoinMarket][jm-install-docs], navigate to JoinMarket's root directory and start
-`jmwalletd` and `ob-watcher`:
+If you have [successfully installed JoinMarket][jm-install-docs], generate a
+self-signed SSL certificate in JoinMarket's working directory, then navigate
+to JoinMarket's root directory and start `jmwalletd` and `ob-watcher`.
+
+In JoinMarket's working directory (e.g. `~/.joinmarket/`):
+```sh
+mkdir ssl/ && cd "$_"
+openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes \
+  -out cert.pem -keyout key.pem \
+  -subj "/C=US/ST=Utah/L=Lehi/O=Your Company, Inc./OU=IT/CN=example.com"
+```
+
+In JoinMarket's root directory:
 
 ```sh
 . jmvenv/bin/activate

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -170,6 +170,10 @@ python3 scripts/jmwalletd.py
 python3 scripts/obwatch/ob-watcher.py --host=127.0.0.1
 ```
 
+!!! info
+    Bind both services to `127.0.0.1` instead of `0.0.0.0` to not expose them to
+    your local network.
+
 It is recommended to install both services as system services, e.g. via
 `systemd`. Also, see your `joinmarket.cfg` config file and adapt the values to
 your needs. It is generally advised to leave all settings at their default
@@ -179,8 +183,9 @@ values. The above commands all use the standard values (e.g. for ports).
 
 
 !!! info
-    Bind both services to `127.0.0.1` instead of `0.0.0.0` to not expose them to
-    your local network.
+    Please make sure to provide values for config variables `max_cj_fee_abs`
+    and `max_cj_fee_rel` in `joinmarket.cfg`. Set them to values you feel
+    comfortable with.
 
 Once `jmwalletd` and `ob-watcher` are running, the last thing to do is to launch
 Jam. You can either run the docker image, or download the source code and run it
@@ -223,7 +228,8 @@ but before starting Jam (either directly or with docker), create a ssh tunnel
 to the remote host.
 
 ```sh
-ssh yourhost.local -v -o GatewayPorts=true -N -L 28183:127.0.0.1:28183 -L 28283:127.0.0.1:28283 -L 62601:127.0.0.1:62601
+ssh yourhost.local -v -o GatewayPorts=true -N \
+  -L 28183:127.0.0.1:28183 -L 28283:127.0.0.1:28283 -L 62601:127.0.0.1:62601
 ```
 
 ---


### PR DESCRIPTION
This PR adds information about generating a self-signed SSL certificate for the `jmwalletd` service:

> In JoinMarket's working directory (e.g. `~/.joinmarket/`):
```sh
mkdir ssl/ && cd "$_"
openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes \
  -out cert.pem -keyout key.pem \
  -subj "/C=US/ST=Utah/L=Lehi/O=Your Company, Inc./OU=IT/CN=example.com"
```
---

Also, a short note on setting config vars `max_cj_fee_abs` and `max_cj_fee_rel` is added:

> Please make sure to provide values for config variables `max_cj_fee_abs` and `max_cj_fee_rel` in `joinmarket.cfg`. Set them to values you feel comfortable with.
