### PR TITLE
docs: fix links

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -78,7 +78,7 @@ You can resolve this by manually deleting the wallet `.lock` file as explained
 in [issue #173][lockfile-issue].
 
 
-[lockfile-issue]: https://github.com/joinmarket-webui/joinmarket-webui/issues/173#issuecomment-1069086553
+[lockfile-issue]: https://github.com/joinmarket-webui/jam/issues/173#issuecomment-1069086553
 
 ### Why is my collaborative transaction taking so long?
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -48,7 +48,7 @@ something in a tasty way (and putting it in [jars][glossary]).
 ![](assets/spaceballs.gif)
 </center>
 
-[name]: https://github.com/joinmarket-webui/joinmarket-webui/issues/22#issuecomment-1024654436
+[name]: https://github.com/joinmarket-webui/jam/issues/22#issuecomment-1024654436
 
 ## About the Philosophy
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -69,11 +69,11 @@ a change.
 If you're good with words and copy editing, or if you want to help to
 translate Jam into multiple languages, [join the translation team][translations].
 
-[milestones]: https://github.com/joinmarket-webui/joinmarket-webui/milestones
+[milestones]: https://github.com/joinmarket-webui/jam/milestones
 
-[issues]: https://github.com/joinmarket-webui/joinmarket-webui/issues
-[pulls]: https://github.com/joinmarket-webui/joinmarket-webui/pulls
-[good-first-issue]: https://github.com/joinmarket-webui/joinmarket-webui/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[issues]: https://github.com/joinmarket-webui/jam/issues
+[pulls]: https://github.com/joinmarket-webui/jam/pulls
+[good-first-issue]: https://github.com/joinmarket-webui/jam/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [translations]: https://www.transifex.com/joinmarket/jam/dashboard/
 [figma]: https://www.figma.com/file/kfejZJFlwBywvLEnPEmJo1/JoinMarket-UI?node-id=2850%3A67638
 
@@ -89,6 +89,6 @@ receiving pull-requests, bug reports, ideas, and feedback from everyone. See the
 participating in this project.
 
 
-[contrib]: https://github.com/joinmarket-webui/joinmarket-webui/blob/master/CONTRIBUTING.md
-[calls]: https://github.com/joinmarket-webui/joinmarket-webui/wiki/community-calls
+[contrib]: https://github.com/joinmarket-webui/jam/blob/master/CONTRIBUTING.md
+[calls]: https://github.com/joinmarket-webui/jam/wiki/community-calls
 [telegram]: https://t.me/JoinMarketWebUI

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ All development is done by volunteers. Consequently, please heed the following
 warning:
 
 !!! danger
-    **Jam is considered beta software.** While JoinMarket is tried and tested, Jam is new and things might break. Use with caution. Please report any issues [directly on GitHub](https://github.com/joinmarket-webui/joinmarket-webui/issues/new).
+    **Jam is considered beta software.** While JoinMarket is tried and tested, Jam is new and things might break. Use with caution. Please report any issues [directly on GitHub](https://github.com/joinmarket-webui/jam/issues/new).
 
 ## Installation
 
@@ -75,4 +75,4 @@ look at the FAQ to get answers to frequently asked questions.
 [faq]: FAQ
 [tgJam]: https://t.me/JoinMarketWebUI
 [mxJam]: https://matrix.to/#/%23jam:bitcoin.kyoto
-[ghJam]: https://github.com/joinmarket-webui/joinmarket-webui/issues
+[ghJam]: https://github.com/joinmarket-webui/jam/issues

--- a/docs/interface/00-cheatsheet.md
+++ b/docs/interface/00-cheatsheet.md
@@ -55,7 +55,7 @@ Click "Cheatsheet" at the bottom of the screen to open up the cheatsheet in Jam.
 Some processes in Jam might take a long time to complete. Further, **Jam is
 considered beta software.** While JoinMarket is tried and tested, Jam is new and
 things might break. Use with caution. Please report any issues [directly on
-GitHub](https://github.com/joinmarket-webui/joinmarket-webui/issues/new).
+GitHub](https://github.com/joinmarket-webui/jam/issues/new).
 
 Make sure to understand the privacy fundamentals, best practices, as well as the
 motivation behind this software. Also, understand that you are participating in

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -108,7 +108,7 @@ docker run --rm  -it \
         --env APP_USER="JAM_USERNAME" \
         --env APP_PASSWORD="****************" \
         --publish "8080:80" \
-        ghcr.io/joinmarket-webui/jam-standalone:v0.1.0-clientserver-v0.9.8
+        ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8
 ```
 
 If you are connecting to a local Bitcoin Core node, use the above command but
@@ -130,7 +130,7 @@ docker run --rm  -it \
         --env APP_USER="jam" \
         --env APP_PASSWORD="AvQ___YOUR_APP_PASSWORD___iCw" \
         --publish "8080:80" \
-        ghcr.io/joinmarket-webui/jam-standalone:v0.1.0-clientserver-v0.9.8
+        ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8
 ```
 
 Please use your password manager or something like `openssl rand -base64 32` to
@@ -202,13 +202,13 @@ docker run --rm  -it \
         --env JAM_JMWALLETD_WEBSOCKET_PORT="28283" \
         --env JAM_JMOBWATCH_PORT="62601" \
         --publish "3000:80" \
-        ghcr.io/joinmarket-webui/jam-ui-only:v0.1.0-clientserver-v0.9.8
+        ghcr.io/joinmarket-webui/jam-ui-only:v0.1.1-clientserver-v0.9.8
 ```
 
 ```sh
 # Option 2: run Jam via npm
 
-git clone https://github.com/joinmarket-webui/jam.git --branch v0.1.0 --depth=1
+git clone https://github.com/joinmarket-webui/jam.git --branch v0.1.1 --depth=1
 cd jam/
 npm install
 npm start

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -96,7 +96,7 @@ The official [Jam standalone docker image][jam-docker-standalone]
 is already bundled with JoinMarket and Tor. It takes care of starting all
 subservices (API, Orderbook, etc.) and everything works out-of-the-box.
 
-[jam-docker-standalone]: https://github.com/joinmarket-webui/jam-docker/pkgs/container/joinmarket-webui-standalone
+[jam-docker-standalone]: https://github.com/joinmarket-webui/jam-docker/pkgs/container/jam-standalone
 
 If you are connecting to a remote Bitcoin Core node, run:
 ```sh

--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -108,7 +108,7 @@ docker run --rm  -it \
         --env APP_USER="JAM_USERNAME" \
         --env APP_PASSWORD="****************" \
         --publish "8080:80" \
-        ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8
+        ghcr.io/joinmarket-webui/jam-standalone:${jam_version}
 ```
 
 If you are connecting to a local Bitcoin Core node, use the above command but
@@ -130,7 +130,7 @@ docker run --rm  -it \
         --env APP_USER="jam" \
         --env APP_PASSWORD="AvQ___YOUR_APP_PASSWORD___iCw" \
         --publish "8080:80" \
-        ghcr.io/joinmarket-webui/jam-standalone:v0.1.1-clientserver-v0.9.8
+        ghcr.io/joinmarket-webui/jam-standalone:${jam_version}
 ```
 
 Please use your password manager or something like `openssl rand -base64 32` to
@@ -202,13 +202,13 @@ docker run --rm  -it \
         --env JAM_JMWALLETD_WEBSOCKET_PORT="28283" \
         --env JAM_JMOBWATCH_PORT="62601" \
         --publish "3000:80" \
-        ghcr.io/joinmarket-webui/jam-ui-only:v0.1.1-clientserver-v0.9.8
+        ghcr.io/joinmarket-webui/jam-ui-only:${jam_version}
 ```
 
 ```sh
 # Option 2: run Jam via npm
 
-git clone https://github.com/joinmarket-webui/jam.git --branch v0.1.1 --depth=1
+git clone https://github.com/joinmarket-webui/jam.git --branch ${jam_version} --depth=1
 cd jam/
 npm install
 npm start

--- a/docs/software/license.md
+++ b/docs/software/license.md
@@ -11,7 +11,7 @@ Both Jam and JoinMarket are released under free and open-source software license
 Jam and is licensed under the [MIT License](https://directory.fsf.org/wiki/License:Expat).
 The Jam documentation is licensed under the [GNU FDL](https://www.gnu.org/licenses/fdl-1.3.en.html).
 
-- Jam [LICENSE](https://github.com/joinmarket-webui/joinmarket-webui/blob/master/LICENSE)
+- Jam [LICENSE](https://github.com/joinmarket-webui/jam/blob/master/LICENSE)
 - JamDocs [LICENSE](https://github.com/joinmarket-webui/jamdocs/blob/master/LICENSE)
 
 ---

--- a/docs/software/verification.md
+++ b/docs/software/verification.md
@@ -40,7 +40,7 @@ It should say that _"This tag was signed with the committer’s verified
 signature"_ and show you the last 16 characters of the GPG key ID listed above
 (`89C4 A25E 69A5 DE7F`).
 
-[releases]: https://github.com/joinmarket-webui/joinmarket-webui/releases
-[contributors]: https://github.com/joinmarket-webui/joinmarket-webui/graphs/contributors
+[releases]: https://github.com/joinmarket-webui/jam/releases
+[contributors]: https://github.com/joinmarket-webui/jam/graphs/contributors
 [now]: https://www.blockstream.info/block-height/742834
 [gigi]: https://dergigi.com/pgp/


### PR DESCRIPTION
Fixes some "old" hyperlinks and adapts version from concrete version string to generic placeholder:
- "joinmarket-webui" -> "jam"
- "joinmarket-webui-standalone" -> "jam-standalone"
- "v0.1.0" -> "${jam_version}"