### PR TITLE
docs(install): add volume and common envs to docker standalone example

### DIFF
--- a/docs/software/installation.md
+++ b/docs/software/installation.md
@@ -107,6 +107,10 @@ docker run --rm  -it \
         --env JM_RPC_PASSWORD="****************" \
         --env APP_USER="JAM_USERNAME" \
         --env APP_PASSWORD="****************" \
+        --env ENSURE_WALLET="true" \
+        --env REMOVE_LOCK_FILES="true" \
+        --env RESTORE_DEFAULT_CONFIG="true" \
+        --volume jmdatadir:/root/.joinmarket \
         --publish "8080:80" \
         ghcr.io/joinmarket-webui/jam-standalone:v0.1.0-clientserver-v0.9.8
 ```
@@ -129,6 +133,10 @@ docker run --rm  -it \
         --env JM_RPC_PASSWORD="n5a___YOUR_RPC_PASSWORD___yNA" \
         --env APP_USER="jam" \
         --env APP_PASSWORD="AvQ___YOUR_APP_PASSWORD___iCw" \
+        --env ENSURE_WALLET="true" \
+        --env REMOVE_LOCK_FILES="true" \
+        --env RESTORE_DEFAULT_CONFIG="true" \
+        --volume jmdatadir:/root/.joinmarket \
         --publish "8080:80" \
         ghcr.io/joinmarket-webui/jam-standalone:v0.1.0-clientserver-v0.9.8
 ```


### PR DESCRIPTION
Adds a volume mapping and common environment variables to the docker standalone examples:
- volume mapping: `--volume jmdatadir:/root/.joinmarket`
  - wihtout a volume mapping, files are ephemeral and e.g. wallets have to be recreated every time
- adds common env variables:
  - `ENSURE_WALLET`: makes sure a wallet on bitcoin core exists and is loaded
  - `REMOVE_LOCK_FILES`: removes lock files before services start up
  - `RESTORE_DEFAULT_CONFIG`: applies the default config of the current jm version before services start up