### PR TITLE
docs(readme): add install and license info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,22 @@
 
 Documentation for [Jam](https://jamapp.org/). Built using mkdocs material theme.
 
+### Install
+```
+pip install mkdocs
+pip install mkdocs-material
+```
+
+### Run
+```
+mkdocs serve
+```
+
+### Build
+```
+mkdocs build
+```
+
+## License
+
+The project is licensed under the GNU Free Documentation License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Adds install/run information to the readme.
Time and again I find myself looking for this info..