### PR TITLE
docs(fb): more prominent info alert for fidelity bonds

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -306,6 +306,11 @@ act honestly. It is a protection mechanism against [Sybil
 attacks](#sybil-attack), because a fidelity bond makes the creation of
 cryptographic identities costly.
 
+!!! warning
+    It is impossible to move or spend funds that are locked in a fidelity bond
+    before the bond expires. They **cannot be used in collaborative transactions**
+    as fidelity bonds are time-locked by the Bitcoin protocol.
+
 Fidelity bonds improve the privacy guarantees of the whole system and increase
 your chance of being chosen as a [market maker](#maker) drastically.
 

--- a/docs/interface/fidelity-bonds.md
+++ b/docs/interface/fidelity-bonds.md
@@ -8,6 +8,11 @@ creation of fraudulent identities.
 
 [glossary]: /glossary/#fidelity-bond
 
+!!! warning
+    It is impossible to move or spend funds that are locked in a fidelity bond
+    before the bond expires. They **cannot be used in collaborative transactions**
+    as fidelity bonds are time-locked by the Bitcoin protocol.
+
 You can create a fidelity bond via the [Earn][earn] screen. It involves the following steps:
 
 1. Set expiration date (which defines the bond's duration)
@@ -17,10 +22,6 @@ You can create a fidelity bond via the [Earn][earn] screen. It involves the foll
 After that, you will be asked to review the bond configuration. If everything
 looks right, you can create the fidelity bond which will [time-lock your
 funds][timelock] for the set duration.
-
-!!! warning
-    It is impossible to move or spend funds that are locked in a fidelity bond
-    before the bond expires, as they are time-locked by the bitcoin protocol.
 
 [earn]: /interface/03-earn/
 [jar]: /glossary/#jar


### PR DESCRIPTION
More prominent indication that FBs cannot be used in collaborative transactions.
Also adds the same warning to the Glossary page.

## Before/After
<img src="https://user-images.githubusercontent.com/3358649/206694724-761db764-fdf8-4bb5-8d4d-1eb0de96f8ec.png" width=300 /> <img src="https://user-images.githubusercontent.com/3358649/206694655-fe78ffac-98b5-4e66-a454-a92c9c738a51.png" width=300 />

