### PR TITLE
docs(faq): info about wallet import via UI

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -160,8 +160,15 @@ curl --insecure https://127.0.0.1:28183/api/v1/session
 
 ### Can I import an existing wallet?
 
-Yes, it is possible to import an existing wallet.
-However, not yet via the web interface, but with a few manual steps via the command line.
+Yes, importing an existing wallet can be done via the web interface since [Jam `v0.1.6`][jam-v0-1-6].
+Just make sure you are running [JoinMarket `v0.9.10`][jm-v0-9-10] or later.
+
+[jam-v0-1-6]: https://github.com/joinmarket-webui/jam/releases/tag/v0.1.6
+[jm-v0-9-10]: https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.10
+
+### How to import wallets via the command line?
+
+If you are running a JoinMarket version lower than `v0.9.10` or if you are a command line maximalist, follow these steps:
 
 - Log into the host machine, e.g. with `ssh` (see an example for Umbrel below)
 - Navigate to JoinMarket's root directory

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -160,8 +160,9 @@ curl --insecure https://127.0.0.1:28183/api/v1/session
 
 ### Can I import an existing wallet?
 
-Yes, importing an existing wallet can be done via the web interface since [Jam `v0.1.6`][jam-v0-1-6].
-Just make sure you are running [JoinMarket `v0.9.10`][jm-v0-9-10] or later.
+Yes, importing an existing wallet can be done via the web interface since [Jam `v0.1.6`][jam-v0-1-6]
+using the button labeled "Import existing wallet" on the starting page.
+Make sure you are running [JoinMarket `v0.9.10`][jm-v0-9-10] or later.
 
 [jam-v0-1-6]: https://github.com/joinmarket-webui/jam/releases/tag/v0.1.6
 [jm-v0-9-10]: https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.10

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -166,7 +166,7 @@ Just make sure you are running [JoinMarket `v0.9.10`][jm-v0-9-10] or later.
 [jam-v0-1-6]: https://github.com/joinmarket-webui/jam/releases/tag/v0.1.6
 [jm-v0-9-10]: https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.10
 
-### How to import wallets via the command line?
+### How to import an existing wallet via the command line?
 
 If you are running a JoinMarket version lower than `v0.9.10` or if you are a command line maximalist, follow these steps:
 

--- a/docs/interface/settings.md
+++ b/docs/interface/settings.md
@@ -26,12 +26,6 @@ wallet can be actively used at a time. Wallets are locked when not used. Your
 - Switch wallet: open another wallet and lock the current one
 - Create new wallet: initialize a new, empty wallet
 
-
-!!! question
-    Want to import a wallet? Look at the [FAQ][faq-import]!
-
-[faq-import]: /FAQ/#can-i-import-an-existing-wallet
-
 ### Community Links
 
 - [Documentation](#): you are here!


### PR DESCRIPTION
Adds the following section to the FAQ page:
> Yes, importing an existing wallet can be done via the web interface since Jam `v0.1.6`.
Just make sure you are running JoinMarket `v0.9.10` or later.

The previously existing paragraph has been moved to "How to import wallets via the command line?".


