### PR TITLE
FAQ: add step-by-step instructions for adding `deprecatedrpc=create_bdb` to conf file

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -238,6 +238,37 @@ The problem should be fixed once JoinMarket supports Bitcoin Core descriptor wal
 
 _For now, the fix is to add `deprecatedrpc=create_bdb` to your bitcoin.conf file._
 
-Restart and then it should work.
+<details>
+<summary>Step-by-step instructions on how to do this on Umbrel/Citadel</summary>
+The example commands are for Umbrel, if you're using Citadel simply replace `umbrel` with `citadel`.
+<br>
+<br>
+
+1. Open the terminal and login to your node using ssh:
+
+`ssh umbrel@umbrel.local`
+<br>
+
+2. Enter your password (same password as when you use the browser).
+<br>
+
+3. Enter command to edit your bitcoin.conf file:
+
+`nano /mnt/data/umbrel/bitcoin/bitcoin.conf`
+<br>
+
+4. Add the config to the config file"
+
+`deprecatedrpc=create_bdb`
+<br>
+
+5. Save and exit the editing of the file, by pressing the following keystroke combo:
+
+`ctrl x` (to save), then `y` (to exit)
+<br>
+
+</details>
+
+Restart and then it should work as the new config is now active.
 
 Or use a lower version than Bitcoin Core v26.0.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -257,7 +257,7 @@ The example commands are for Umbrel, if you're using Citadel simply replace `umb
 `nano /mnt/data/umbrel/bitcoin/bitcoin.conf`
 <br>
 
-4. Add the config to the config file"
+4. Add the following line to the config file
 
 `deprecatedrpc=create_bdb`
 <br>


### PR DESCRIPTION
it's a big problem as people want to try Jam for the first time and then it doesn't work.
So adding step-by-step instructions on how to fix it is important, and gets requested all the time.
Almost always by umbrel users

made it a dropdown to not overcrowd the FAQ

![stepbystep](https://github.com/joinmarket-webui/jamdocs/assets/93143998/3f0364b1-a2ce-4d2c-831e-01b0530cc8fa)

[stepybystep.webm](https://github.com/joinmarket-webui/jamdocs/assets/93143998/a0416f92-99c2-403c-9ecc-4ea286a37ce6)

